### PR TITLE
remove streamnator because of error

### DIFF
--- a/@Tactical_Training_Team/addons/ttt_teleporter/config.cpp
+++ b/@Tactical_Training_Team/addons/ttt_teleporter/config.cpp
@@ -17,11 +17,3 @@ class CfgFunctions {
 };
 
 #include "W_Teleporter\dialog.hpp"
-
-class CLib {
-    Modules[] = {"CLib", "Streamator"};
-    useExperimentalAutoload = 0;
-    useCompressedFunction = 0;
-    useFallbackRemoteExecution = 0;
-    FrameGraphSize = 128;
-};

--- a/@Tactical_Training_Team/addons/ttt_teleporter/init.sqf
+++ b/@Tactical_Training_Team/addons/ttt_teleporter/init.sqf
@@ -1,10 +1,6 @@
 //by Nobody ©
-//V 0.2023.08081924
-//TTT automate Teleport, Streamator & Spectator
-
-//Clib (Streamator)
-if !(isNil "CLib_fnc_loadModules") then { call CLib_fnc_loadModules;};
-
+//V 0.2023.08311112
+//TTT automate Teleport
 
 // set 'ttt_teleport_logic = false;' to deaktiveate logic
 // waituntil {!isnil "bis_fnc_init"};


### PR DESCRIPTION
Wenn Streamnator in Mission verbaut und im Mod dann lässt sich die Mission nicht starten. Daher wird er im Mod entfernt bis er dort gefixt werden konnte und nicht mehr in der Mission verbaut werden muss.